### PR TITLE
TILES-6869 fix depth msaa

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -21,6 +21,23 @@ map.once('idle', () => {
     initDeckGL();
 });
 
+const buildingLayer = {
+    id: 'house private',
+    name: 'Частные дома',
+    type: 'polygonExtrusion',
+    style: {
+        topColor: '#00ff00',
+        sideColor: 'rgba(255,62,54,0.82)',
+    },
+    filter: ['match', ['get', 'sublayer'], ['Technical_house'], true, false],
+    minzoom: 16,
+    metadata: {
+        group: {
+            id: '746776',
+        },
+    },
+};
+
 function initDeckGL() {
     const deckLayer1 = createHeatmapLayer(data);
     map.addLayer(deckLayer1);
@@ -32,6 +49,7 @@ function initDeckGL() {
     map.addLayer(deckLayer4);
     map.removeLayer('deckgl-HexagonLayer');
     map.addLayer(deckLayer2);
+    map.addLayer(buildingLayer);
 }
 
 const COLOR_RANGE: Color[] = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2gis/deck2gis-layer",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@2gis/deck2gis-layer",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@2gis/gl-matrix": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/deck2gis-layer",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "",
   "main": "dist/deck2gislayer.js",
   "typings": "dist/types/index.d.ts",

--- a/src/deckgl2gisLayer.ts
+++ b/src/deckgl2gisLayer.ts
@@ -218,9 +218,10 @@ export class Deck2gisLayer<LayerT extends Layer> implements DeckCustomLayer {
 
         this.programmBinder();
 
+        const prevDepthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
         gl.depthMask(false);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
-        gl.depthMask(true);
+        gl.depthMask(prevDepthMask);
 
         (this.props.deck as any).glStateStore.useMapglWebglState();
     };

--- a/src/deckgl2gisLayer.ts
+++ b/src/deckgl2gisLayer.ts
@@ -218,7 +218,10 @@ export class Deck2gisLayer<LayerT extends Layer> implements DeckCustomLayer {
 
         this.programmBinder();
 
+        gl.depthMask(false);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
+        gl.depthMask(true);
+
         (this.props.deck as any).glStateStore.useMapglWebglState();
     };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,7 +123,6 @@ export function drawLayer(deck: Deck, map: Map, layer: Deck2gisLayer<any>): bool
     if (!isIncludeLayer(deck, layer)) {
         return false;
     }
-    stateBinder(map.getWebGLContext());
 
     deck._drawLayers('2gis-repaint', {
         viewports: [currentViewport],
@@ -484,16 +483,6 @@ function initDeck2gisProps(map: Map, deckProps?: CustomRenderProps): DeckProps {
         viewState: getViewState(map),
     });
     return deck2gisProps;
-}
-
-// Fix heatmap layer render: need reset gl state after each draw layers
-/**
- * @hidden
- * @internal
- */
-function stateBinder(gl: WebGLRenderingContext | WebGL2RenderingContext) {
-    gl.clearDepth(1);
-    gl.clear(gl.DEPTH_BUFFER_BIT);
 }
 
 /**


### PR DESCRIPTION
- Fixed msaa texture drawing on canvas, depth mask from texture to canvas is now disabled.
- Skip use stateBinder function for fix heatmap layer - this fix was not will be useful. 