### PR TITLE
PRO-9420: обновлена версия deck

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -108,7 +108,7 @@ function createHeatmapLayer(data) {
     return layer;
 }
 function createHexagonLayer(data) {
-    const layer = new Deck2gisLayer<HexagonLayer>({
+    const layer = new Deck2gisLayer<HexagonLayer<any>>({
         id: 'deckgl-HexagonLayer',
         deck,
         colorRange: COLOR_RANGE,
@@ -126,7 +126,7 @@ function createHexagonLayer(data) {
 }
 
 function createHexagonLayer2(data) {
-    const layer = new Deck2gisLayer<HexagonLayer>({
+    const layer = new Deck2gisLayer<HexagonLayer<any>>({
         id: 'deckgl-HexagonLayer2',
         deck,
         colorRange: COLOR_RANGE,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@2gis/gl-matrix": "^2.4.6",
-        "@deck.gl/core": "8.8.17",
+        "@deck.gl/core": "8.9.36",
         "gl-state": "^1.0.0",
         "uniq": "^1.0.1"
       },
       "devDependencies": {
-        "@2gis/mapgl": "1.42.0",
+        "@2gis/mapgl": "1.66.0",
         "@2gis/ts-docs-generator": "^0.1.0",
-        "@deck.gl/aggregation-layers": "8.8.17",
-        "@deck.gl/layers": "8.8.17",
+        "@deck.gl/aggregation-layers": "8.9.36",
+        "@deck.gl/layers": "8.9.36",
         "@types/jest": "^27.4.0",
         "@types/jest-image-snapshot": "^4.3.1",
         "@types/puppeteer": "^5.4.4",
@@ -48,10 +48,11 @@
       "license": "MIT"
     },
     "node_modules/@2gis/mapgl": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@2gis/mapgl/-/mapgl-1.42.0.tgz",
-      "integrity": "sha512-c0sGGVnjdTs6uD5urFo1yoSKrr7jcd7CVPfh+kDGlnkIkswfCA7V674GmvY4XUmVpgDY01pjacO4/It//rwEAA==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@2gis/mapgl/-/mapgl-1.66.0.tgz",
+      "integrity": "sha512-l7XqvFmxbBnAGLso2QgG3/vxXqt4xMLDDWmDv7Hfzefd+skWqVWrbNKG5qGQSm1E0xQBkcS0Wimlju7c30/IsQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
       },
@@ -627,12 +628,15 @@
       "dev": true
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "8.8.17",
+      "version": "8.9.36",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.9.36.tgz",
+      "integrity": "sha512-EwUJ1bwhhAG6LF9hAdZDaIAwIFDUGC8XpQgHmitTLohciVrIp70p9zpgHNNU6oPy+iQvccmWctLcSC9TpgjsIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "^8.5.16",
-        "@luma.gl/shadertools": "^8.5.16",
+        "@babel/runtime": "^7.0.0",
+        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/shadertools": "^8.5.21",
         "@math.gl/web-mercator": "^3.6.2",
         "d3-hexbin": "^0.2.1"
       },
@@ -643,13 +647,17 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "8.8.17",
+      "version": "8.9.36",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.36.tgz",
+      "integrity": "sha512-mkIv4/fY1jE+iehqSJzUQi75l9cgfx2ZBa1s1AifgLu0TCkCZgRgISV3UnDBECDCmTZ9Cqk+oKq3OGay3Bz1RQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/core": "^3.2.10",
-        "@loaders.gl/images": "^3.2.10",
-        "@luma.gl/constants": "^8.5.16",
-        "@luma.gl/core": "^8.5.16",
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/core": "^3.4.13",
+        "@loaders.gl/images": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/core": "^8.5.21",
+        "@luma.gl/webgl": "^8.5.21",
         "@math.gl/core": "^3.6.2",
         "@math.gl/sun": "^3.6.2",
         "@math.gl/web-mercator": "^3.6.2",
@@ -662,22 +670,25 @@
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "8.8.17",
+      "version": "8.9.36",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.36.tgz",
+      "integrity": "sha512-sr/QKELXZ4W0ZHb12QC2+EV1bZJOM6cU6kAfOJD5jOVixOcyccr+FnPPGn39VK9cl/VFY0S339ZPs9reyhDFVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "^3.2.10",
-        "@loaders.gl/schema": "^3.2.10",
-        "@luma.gl/constants": "^8.5.16",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@babel/runtime": "^7.0.0",
+        "@loaders.gl/images": "^3.4.13",
+        "@loaders.gl/schema": "^3.4.13",
+        "@luma.gl/constants": "^8.5.21",
+        "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^3.6.2",
         "@math.gl/polygon": "^3.6.2",
         "@math.gl/web-mercator": "^3.6.2",
-        "earcut": "^2.0.6"
+        "earcut": "^2.2.4"
       },
       "peerDependencies": {
         "@deck.gl/core": "^8.0.0",
-        "@loaders.gl/core": "^3.0.0",
+        "@loaders.gl/core": "^3.4.13",
         "@luma.gl/core": "^8.0.0"
       }
     },
@@ -2429,55 +2440,41 @@
       }
     },
     "node_modules/@loaders.gl/core": {
-      "version": "3.4.6",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.15.tgz",
+      "integrity": "sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.4.6",
-        "@loaders.gl/worker-utils": "3.4.6",
-        "@probe.gl/log": "^4.0.1"
-      }
-    },
-    "node_modules/@loaders.gl/core/node_modules/@probe.gl/env": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
-    },
-    "node_modules/@loaders.gl/core/node_modules/@probe.gl/log": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "4.0.4"
+        "@loaders.gl/loader-utils": "3.4.15",
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/log": "^3.5.0"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.4.6",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.15.tgz",
+      "integrity": "sha512-QpjYhEetHabY/z9mWZYJXZZp4XJAxa38f9Ii/DjPlnJErepzY5GLBUTDHMu4oZ6n99gGImtuGFicDnFV6mb60g==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.4.6"
+        "@loaders.gl/loader-utils": "3.4.15"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.4.6",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz",
+      "integrity": "sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.4.6",
-        "@probe.gl/stats": "^4.0.1"
-      }
-    },
-    "node_modules/@loaders.gl/loader-utils/node_modules/@probe.gl/stats": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@loaders.gl/worker-utils": "3.4.15",
+        "@probe.gl/stats": "^3.5.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.4.6",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.15.tgz",
+      "integrity": "sha512-8oRtstz0IsqES7eZd2jQbmCnmExCMtL8T6jWd1+BfmnuyZnQ0B6TNccy++NHtffHdYuzEoQgSELwcdmhSApYew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2485,37 +2482,45 @@
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.4.6",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz",
+      "integrity": "sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1"
       }
     },
     "node_modules/@luma.gl/constants": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz",
+      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA==",
       "license": "MIT"
     },
     "node_modules/@luma.gl/core": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.21.tgz",
+      "integrity": "sha512-11jQJQEMoR/IN2oIsd4zFxiQJk6FE+xgVIMUcsCTBuzafTtQZ8Po9df8mt+MVewpDyBlTVs6g8nxHRH4np1ukA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.20",
-        "@luma.gl/engine": "8.5.20",
-        "@luma.gl/gltools": "8.5.20",
-        "@luma.gl/shadertools": "8.5.20",
-        "@luma.gl/webgl": "8.5.20"
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/engine": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
+        "@luma.gl/shadertools": "8.5.21",
+        "@luma.gl/webgl": "8.5.21"
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.21.tgz",
+      "integrity": "sha512-IG3WQSKXFNUEs8QG7ZjHtGiOtsakUu+BAxtJ6997A6/F06yynZ44tPe5NU70jG9Yfu3kV0LykPZg7hO3vXZDiA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.20",
-        "@luma.gl/gltools": "8.5.20",
-        "@luma.gl/shadertools": "8.5.20",
-        "@luma.gl/webgl": "8.5.20",
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
+        "@luma.gl/shadertools": "8.5.21",
+        "@luma.gl/webgl": "8.5.21",
         "@math.gl/core": "^3.5.0",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0",
@@ -2523,18 +2528,22 @@
       }
     },
     "node_modules/@luma.gl/gltools": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.21.tgz",
+      "integrity": "sha512-6qZ0LaT2Mxa4AJT5F44TFoaziokYiHUwO45vnM/NYUOIu9xevcmS6VtToawytMEACGL6PDeDyVqP3Y80SDzq5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/constants": "8.5.21",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/log": "^3.5.0",
         "@types/offscreencanvas": "^2019.7.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.21.tgz",
+      "integrity": "sha512-WQah7yFDJ8cNCLPYpIm3r0wSlXLvjoA279fcknmATvvkW3/i8PcCJ/nYEBJO3hHEwwMQxD16+YZu/uwGiifLMg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -2542,18 +2551,22 @@
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "8.5.20",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.21.tgz",
+      "integrity": "sha512-ZVLO4W5UuaOlzZIwmFWhnmZ1gYoU97a+heMqxLrSSmCUAsSu3ZETUex9gOmzdM1WWxcdWaa3M68rvKCNEgwz0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.20",
-        "@luma.gl/gltools": "8.5.20",
+        "@luma.gl/constants": "8.5.21",
+        "@luma.gl/gltools": "8.5.21",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0"
       }
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "1.2.5",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
@@ -2818,7 +2831,9 @@
       }
     },
     "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.0",
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
     "node_modules/@types/pixelmatch": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   ],
   "devDependencies": {
     "@2gis/ts-docs-generator": "^0.1.0",
-    "@2gis/mapgl": "1.42.0",
-    "@deck.gl/aggregation-layers": "8.8.17",
-    "@deck.gl/layers": "8.8.17",
+    "@2gis/mapgl": "1.66.0",
+    "@deck.gl/aggregation-layers": "8.9.36",
+    "@deck.gl/layers": "8.9.36",
     "@types/jest": "^27.4.0",
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/puppeteer": "^5.4.4",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@2gis/gl-matrix": "^2.4.6",
-    "@deck.gl/core": "8.8.17",
+    "@deck.gl/core": "8.9.36",
     "gl-state": "^1.0.0",
     "uniq": "^1.0.1"
   },

--- a/test/screenshots/plugin.screen.ts
+++ b/test/screenshots/plugin.screen.ts
@@ -87,7 +87,7 @@ describe('Base tests', () => {
                 },
             ];
 
-            const deckHexagonLayer = new window.Deck2gisLayer<HexagonLayer>({
+            const deckHexagonLayer = new window.Deck2gisLayer<HexagonLayer<any>>({
                 id: 'deckgl-HexagonLayer',
                 deck: window.deckgl,
                 type: window.HexagonLayer,


### PR DESCRIPTION
В PRO переехали на deck 8.9.36 в рамках https://jira.2gis.ru/browse/PRO-9420  Вот и тут тоже надо обновиться, а то текущая версия выдает ошибки в композитных слоях.

<img width="732" height="188" alt="Screenshot 2025-10-10 at 17 50 31" src="https://github.com/user-attachments/assets/9987aec7-71e9-44c3-8363-9081de33bd08" />
